### PR TITLE
Use env in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ php artisan vendor:publish --provider="Contentful\Laravel\ContentfulServiceProvi
 
 This will add `contentful.php` to your `/config` folder. Next, add your space ID and API key to your `.env` file:
 
-    CONTENTFUL_DELIVERY_SPACE="cfexampleapi"
+    CONTENTFUL_SPACE_ID="cfexampleapi"
     CONTENTFUL_DELIVERY_TOKEN="b4c0n73n7fu1"
 
 ## License

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Publish the config file:
 php artisan vendor:publish --provider="Contentful\Laravel\ContentfulServiceProvider"
 ```
 
-This will add `contentful.php` to your `/config` folder. Next, open that file and add your space ID and API key.
+This will add `contentful.php` to your `/config` folder. Next, add your space ID and API key to your `.env` file:
+
+    CONTENTFUL_DELIVERY_SPACE="cfexampleapi"
+    CONTENTFUL_DELIVERY_TOKEN="b4c0n73n7fu1"
 
 ## License
 

--- a/src/config/contentful.php
+++ b/src/config/contentful.php
@@ -8,20 +8,20 @@ return [
     /**
      * The ID of the space you want to access
      */
-    'delivery.space' => '',
+    'delivery.space' => env('CONTENTFUL_DELIVERY_SPACE'),
 
     /**
      * An API key for the above specified space
      */
-    'delivery.token' => '',
+    'delivery.token' => env('CONTENTFUL_DELIVERY_TOKEN'),
 
     /**
      * Controls whether Contentful's Delivery or Preview API is accessed
      */
-    'delivery.preview' => false,
+    'delivery.preview' => env('CONTENTFUL_DELIVERY_PREVIEW', false),
 
     /**
      * Sets the locale in which to fetch content by default. NULL means the space'd default locale will be used
      */
-    'delivery.defaultLocale' => null
+    'delivery.defaultLocale' => env('CONTENTFUL_DELIVERY_LOCALE'),
 ];

--- a/src/config/contentful.php
+++ b/src/config/contentful.php
@@ -8,7 +8,7 @@ return [
     /**
      * The ID of the space you want to access
      */
-    'delivery.space' => env('CONTENTFUL_DELIVERY_SPACE'),
+    'delivery.space' => env('CONTENTFUL_SPACE_ID'),
 
     /**
      * An API key for the above specified space
@@ -18,10 +18,10 @@ return [
     /**
      * Controls whether Contentful's Delivery or Preview API is accessed
      */
-    'delivery.preview' => env('CONTENTFUL_DELIVERY_PREVIEW', false),
+    'delivery.preview' => env('CONTENTFUL_USE_PREVIEW', false),
 
     /**
      * Sets the locale in which to fetch content by default. NULL means the space'd default locale will be used
      */
-    'delivery.defaultLocale' => env('CONTENTFUL_DELIVERY_LOCALE'),
+    'delivery.defaultLocale' => env('CONTENTFUL_DEFAULT_LOCALE'),
 ];


### PR DESCRIPTION
I updated the config to use env vars. This saves users the extra step of manually updating their config to use env when installing this package.

I think this documentation should be updated to instruct uses to use env vars, rather than adding API keys to the source, as well:

https://www.contentful.com/developers/docs/php/tutorials/getting-started-with-contentful-and-laravel/#configuration