### PR TITLE
feat!: add Laravel 13 support, drop EOL PHP 8.0/8.1 [DX-925]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ workflows:
       - lintSyntax
       - lintStaticAnalysis
       - checkBcBreaks
-      - test80
-      - test81
       - test82
       - test83
       - test84
@@ -54,22 +52,6 @@ jobs:
           name: Check for backwards-compatibility breaks
           command: composer run test-for-bc-breaks || true
 
-
-  test80:
-    docker:
-      - image: cimg/php:8.0
-    steps:
-      - checkout
-      - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist --ignore-platform-reqs" }
-      - run: { name: "Test suite", command: "composer test-quick-fail" }
-
-  test81:
-    docker:
-      - image: cimg/php:8.1
-    steps:
-      - checkout
-      - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist" }
-      - run: { name: "Test suite", command: "composer test-quick-fail" }
 
   test82:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
 jobs:
   lintStaticAnalysis:
     docker:
-      - image: cimg/php:8.1
+      - image: cimg/php:8.2
     steps:
       - checkout
       - run:
@@ -27,7 +27,7 @@ jobs:
 
   lintSyntax:
     docker:
-      - image: cimg/php:8.1
+      - image: cimg/php:8.2
     steps:
       - checkout
       - run:
@@ -42,7 +42,7 @@ jobs:
 
   checkBcBreaks:
     docker:
-      - image: cimg/php:8.1
+      - image: cimg/php:8.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - image: cimg/php:8.0
     steps:
       - checkout
-      - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist" }
+      - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist --ignore-platform-reqs" }
       - run: { name: "Test suite", command: "composer test-quick-fail" }
 
   test81:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/contentful/contentful-laravel/compare/9.0.2...HEAD)
+## [Unreleased](https://github.com/contentful/contentful-laravel/compare/9.1.0...HEAD)
 
 <!-- PENDING-CHANGES -->
 > No meaningful changes since last release.
 <!-- /PENDING-CHANGES -->
+
+## [9.1.0](https://github.com/contentful/contentful-laravel/tree/9.1.0) (2026-04-09)
+
+## Added
+
+> Support for Laravel 13
 
 ## [9.0.2](https://github.com/contentful/contentful-laravel/tree/9.0.2) (2024-04-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/contentful/contentful-laravel/compare/9.1.0...HEAD)
+## [Unreleased](https://github.com/contentful/contentful-laravel/compare/10.0.0...HEAD)
 
 <!-- PENDING-CHANGES -->
 > No meaningful changes since last release.
 <!-- /PENDING-CHANGES -->
 
-## [9.1.0](https://github.com/contentful/contentful-laravel/tree/9.1.0) (2026-04-09)
+## [10.0.0](https://github.com/contentful/contentful-laravel/tree/10.0.0) (2026-04-09)
 
 ## Added
 
 > Support for Laravel 13
+
+## Removed
+
+> Support for PHP 8.0 and 8.1 (EOL)
 
 ## [9.0.2](https://github.com/contentful/contentful-laravel/tree/9.0.2) (2024-04-02)
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "contentful/contentful": "^7.0.1",
         "contentful/core": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "contentful/contentful": "^7.0.1",
         "contentful/core": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-quick-fail": "php vendor/bin/phpunit --stop-on-error --stop-on-failure",
+        "test-quick-fail": "php vendor/bin/phpunit --stop-on-error --stop-on-failure --no-coverage",
         "lint-static-analysis": "php vendor/bin/phpstan analyse src --level=5",
         "release": "php vendor/contentful/core/scripts/release.php"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-quick-fail": "php vendor/bin/phpunit --stop-on-error --stop-on-failure -v",
+        "test-quick-fail": "php vendor/bin/phpunit --stop-on-error --stop-on-failure",
         "lint-static-analysis": "php vendor/bin/phpstan analyse src --level=5",
         "release": "php vendor/contentful/core/scripts/release.php"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "contentful/core": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "orchestra/testbench": "^5.1|^6.0",
+        "phpunit/phpunit": "^8.5|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^5.1|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpstan/phpstan": "^1.9"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,12 @@
         </include>
     </source>
 
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70" />
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
     <php>
         <env name="CONTENTFUL_SPACE_ID" value="cfexampleapi" />
         <env name="CONTENTFUL_DELIVERY_TOKEN" value="b4c0n73n7fu1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,16 +6,11 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70" />
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 
     <php>
         <env name="CONTENTFUL_SPACE_ID" value="cfexampleapi" />


### PR DESCRIPTION
[DX-925](https://contentful.atlassian.net/browse/DX-925)

## Summary
- Adds `^13.0` to the `laravel/framework` constraint in `composer.json`
- Bumps `orchestra/testbench` and `phpunit` dev constraints to support Laravel 13 in CI
- Updates `phpunit.xml.dist` to PHPUnit 10+ format
- Updates CHANGELOG with v9.1.0 entry

## Test plan
- [ ] CircleCI passes across PHP 8.0–8.4 matrix
- [ ] `composer require contentful/laravel` resolves cleanly on a Laravel 13 project
- [ ] Existing functionality unaffected on Laravel 8–12

Generated with [Claude Code](https://claude.com/claude-code)

[DX-925]: https://contentful.atlassian.net/browse/DX-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds support for Laravel 13 by updating the laravel/framework constraint in composer.json to include ^13.0, drops support for EOL PHP 8.0 and 8.1 by updating minimum PHP requirement to ^8.2, removes corresponding CI test jobs, updates base PHP images in CircleCI config, modernizes PHPUnit configuration, and documents the changes in the CHANGELOG.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates composer.json to require PHP ^8.2, adds ^13.0 to laravel/framework constraint, and expands version ranges for phpunit and orchestra/testbench dev dependencies</li>

<li>Removes test80 and test81 jobs from .circleci/config.yml, updates PHP Docker images from 8.1 to 8.2 in remaining jobs</li>

<li>Replaces deprecated <logging> and <filter> elements with <source> and <coverage> elements in phpunit.xml.dist, adds --no-coverage to test-quick-fail script</li>

<li>Updates CHANGELOG.md with 10.0.0 release entry documenting Laravel 13 support addition and PHP 8.0/8.1 removal</li>

</ul>
</details>

</div>